### PR TITLE
fix issue #31

### DIFF
--- a/src/Tidal/XboxUI/XboxSettingsPage.xaml.cpp
+++ b/src/Tidal/XboxUI/XboxSettingsPage.xaml.cpp
@@ -53,13 +53,29 @@ concurrency::task<void> Tidal::XboxSettingsPage::loadStorageStatisticsAsync()
 
 void Tidal::XboxSettingsPage::OnStreamingQualityChecked(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
 {
+    auto settingsValues = Windows::Storage::ApplicationData::Current->LocalSettings->Values;
+    auto fe = dynamic_cast<FrameworkElement^>(sender);
+    if (fe) {
+        auto quality = dynamic_cast<String^>(fe->Tag);
+        if (quality) {
 
+            settingsValues->Insert(L"streamingQuality", quality);
+        }
+    }
 }
 
 
 void Tidal::XboxSettingsPage::OnImportQualityChecked(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
 {
+    auto settingsValues = Windows::Storage::ApplicationData::Current->LocalSettings->Values;
+    auto fe = dynamic_cast<FrameworkElement^>(sender);
+    if (fe) {
+        auto quality = dynamic_cast<String^>(fe->Tag);
+        if (quality) {
 
+            settingsValues->Insert(L"importQuality", quality);
+        }
+    }
 }
 
 


### PR DESCRIPTION
methods to save settings on xbox were empty. Copied methods from
Settings.xaml.cpp.